### PR TITLE
Cosmetical changes to enhance readability of SC cmake output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-
+cmake_policy(SET CMP0048 OLD)
 project(hidapi)
 
 set(VERSION_MAJOR "0")
@@ -52,7 +52,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   if(NOT HIDAPI MATCHES "^(libusb|hidraw)$")
         message(WARNING "Unrecognised hid API: ${HIDAPI}")
   endif()
-  
+
   if (HIDAPI STREQUAL hidraw)
     add_subdirectory(linux)
   #   set( hidapi_source ${hidapi_SOURCE_DIR}/linux )
@@ -60,7 +60,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   elseif (HIDAPI STREQUAL libusb)
     add_subdirectory(libusb)
   #   set( hidapi_source ${hidapi_SOURCE_DIR}/libusb )
-    link_directories( ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES} )  
+    link_directories( ${LIBUSB_1_LIBRARIES} ${PTHREADS_LIBRARIES} )
   endif()
 
 endif()

--- a/hidapi/CMakeLists.txt
+++ b/hidapi/CMakeLists.txt
@@ -1,1 +1,1 @@
-message( "hidapi cmakelists" )
+message(STATUS "HIDAPI components:" )

--- a/hidapi2osc/CMakeLists.txt
+++ b/hidapi2osc/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===hidapi2osc cmakelists===" )
+message(STATUS "    hidapi2osc" )
 
 include(FindPkgConfig)
 # pkg_check_modules

--- a/hidapi_parser/CMakeLists.txt
+++ b/hidapi_parser/CMakeLists.txt
@@ -1,12 +1,12 @@
-message( "===hidapi_parser cmakelists===" )
+message(STATUS "    hidapi_parser" )
 
 
 # message( "hidapi parser source dir is: ${hidapi_SOURCE_DIR}" )
-# 
+#
 # set( hidapi_parser_INCLUDE_DIRS ${hidapi_SOURCE_DIR}/hidapi_parser/)
 # # set( hidapi_LIBS ${UDEV_LIBRARIES})
 # set( hidapi_parser_SRCS hidapi_parser.c )
-# 
+#
 # message( "hidapi_parser include dirs are: ${hidapi_parser_INCLUDE_DIRS}" )
 
 include_directories( ${hidapi_SOURCE_DIR}/hidapi/ )

--- a/hidparsertest/CMakeLists.txt
+++ b/hidparsertest/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===hidparsertest cmakelists===" )
+message(STATUS "    hidparsertest" )
 
 include_directories(
   ${CMAKE_BINARY_DIR}

--- a/hidtest/CMakeLists.txt
+++ b/hidtest/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===hidtest cmakelists===" )
+message(STATUS "    hidtest" )
 
 include_directories(
   ${CMAKE_BINARY_DIR}

--- a/hidtestosx/CMakeLists.txt
+++ b/hidtestosx/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===hidtestosx cmakelists===" )
+message(STATUS "    hidtestosx" )
 
 include_directories(
   ${CMAKE_BINARY_DIR}

--- a/libusb/CMakeLists.txt
+++ b/libusb/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===libusb cmakelists===" )
+message(STATUS "    libusb" )
 
 
 #rt - clock_gettime
@@ -20,7 +20,7 @@ find_package( libusb-1.0 )
 ## NOT TESTED:
 IF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   find_package( IConv )
-ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD") 
+ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 
 #TODO: ADD ICONV
 # set( hidapi_INCLUDE_DIRS ${LIBUSB_1_INCLUDE_DIRS} ${hidapi_SOURCE_DIR}/hidapi/ ${PTHREADS_INCLUDE_DIR})

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===linux hidraw cmakelists===" )
+message(STATUS "    linux hidraw" )
 
 #udev
 find_package(UDev)

--- a/mac/CMakeLists.txt
+++ b/mac/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===mac cmakelists===" )
+message(STATUS "    mac" )
 
 #pthreads
 #-framework IOKit -framework CoreFoundation

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-message( "===windows cmakelists===" )
+message(STATUS "    Windows" )
 
 include_directories( ${hidapi_SOURCE_DIR}/hidapi/ )
 add_library( hidapi STATIC hid.c )


### PR DESCRIPTION
What the subject line says. You might not see the problem in your system. On systems using recent cmake a multiline warning is returned because of that project/version policy issue. It distorts the sc cmake output for no reason.
